### PR TITLE
Docstrings DataFrame

### DIFF
--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -334,6 +334,58 @@ class DataFrame(BaseFrame):
             raise TypeError(msg)
 
     def to_pandas(self) -> Any:
+        r"""
+        Convert this DataFrame to a pandas DataFrame.
+
+        Returns:
+            A pandas DataFrame.
+
+        Notes:
+            This operation requires that `pandas` is installed.
+
+        Examples:
+            >>> import polars as pl
+            >>> import narwhals as nw
+            >>> df_pl = pl.DataFrame(
+            ...     {
+            ...         "foo": [1, 2, 3],
+            ...         "bar": [6.0, 7.0, 8.0],
+            ...         "ham": ["a", "b", "c"],
+            ...     }
+            ... )
+            >>> df = nw.DataFrame(df_pl)
+            >>> df
+            ┌─────────────────────────────────────────────────┐
+            | Narwhals DataFrame                              |
+            | Use `narwhals.to_native()` to see native output |
+            └─────────────────────────────────────────────────┘
+            >>> df.to_pandas()
+               foo  bar ham
+            0    1  6.0   a
+            1    2  7.0   b
+            2    3  8.0   c
+
+            Null values in numeric columns are converted to `NaN`.
+
+            >>> df_pl = pl.DataFrame(
+            ...     {
+            ...         "foo": [1, 2, None],
+            ...         "bar": [6.0, None, 8.0],
+            ...         "ham": [None, "b", "c"],
+            ...     }
+            ... )
+            >>> df = nw.DataFrame(df_pl)
+            >>> df
+            ┌─────────────────────────────────────────────────┐
+            | Narwhals DataFrame                              |
+            | Use `narwhals.to_native()` to see native output |
+            └─────────────────────────────────────────────────┘
+            >>> df.to_pandas()
+               foo  bar   ham
+            0  1.0  6.0  None
+            1  2.0  NaN     b
+            2  NaN  8.0     c
+        """
         return self._dataframe.to_pandas()
 
     def to_numpy(self) -> Any:

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -330,7 +330,7 @@ class DataFrame(BaseFrame):
         ):  # pragma: no cover
             self._dataframe = PandasDataFrame(df, implementation="cudf")
         else:
-            msg = f"Expected pandas-like dataframe, or Polars dataframe, got: {type(df)}"
+            msg = f"Expected pandas-like dataframe, Polars dataframe, or Polars lazyframe, got: {type(df)}"
             raise TypeError(msg)
 
     def to_pandas(self) -> Any:

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -189,116 +189,6 @@ class DataFrame(BaseFrame):
         │ 1   ┆ 3   │
         │ 2   ┆ 4   │
         └─────┴─────┘
-
-        To specify a more detailed/specific frame schema you can supply the `schema`
-        parameter with a dictionary of (name,dtype) pairs...
-
-        >>> data = {"col1": [0, 2], "col2": [3, 7]}
-        >>> df_pl2 = pl.DataFrame(data, schema={"col1": pl.Float32, "col2": pl.Int64})
-        >>> df2 = nw.DataFrame(df_pl2)
-        >>> df2
-        ┌─────────────────────────────────────────────────┐
-        | Narwhals DataFrame                              |
-        | Use `narwhals.to_native()` to see native output |
-        └─────────────────────────────────────────────────┘
-        >>> nw.to_native(df2)
-        shape: (2, 2)
-        ┌──────┬──────┐
-        │ col1 ┆ col2 │
-        │ ---  ┆ ---  │
-        │ f32  ┆ i64  │
-        ╞══════╪══════╡
-        │ 0.0  ┆ 3    │
-        │ 2.0  ┆ 7    │
-        └──────┴──────┘
-
-        ...a sequence of (name,dtype) pairs...
-
-        >>> data = {"col1": [1, 2], "col2": [3, 4]}
-        >>> df_pl3 = pl.DataFrame(data, schema=[("col1", pl.Float32), ("col2", pl.Int64)])
-        >>> df3 = nw.DataFrame(df_pl3)
-        >>> df3
-        ┌─────────────────────────────────────────────────┐
-        | Narwhals DataFrame                              |
-        | Use `narwhals.to_native()` to see native output |
-        └─────────────────────────────────────────────────┘
-        >>> nw.to_native(df3)
-        shape: (2, 2)
-        ┌──────┬──────┐
-        │ col1 ┆ col2 │
-        │ ---  ┆ ---  │
-        │ f32  ┆ i64  │
-        ╞══════╪══════╡
-        │ 1.0  ┆ 3    │
-        │ 2.0  ┆ 4    │
-        └──────┴──────┘
-
-        ...or a list of typed Series.
-
-        >>> data = [
-        ...     pl.Series("col1", [1, 2], dtype=pl.Float32),
-        ...     pl.Series("col2", [3, 4], dtype=pl.Int64),
-        ... ]
-        >>> df_pl4 = pl.DataFrame(data)
-        >>> df4 = nw.DataFrame(df_pl4)
-        >>> df4
-        ┌─────────────────────────────────────────────────┐
-        | Narwhals DataFrame                              |
-        | Use `narwhals.to_native()` to see native output |
-        └─────────────────────────────────────────────────┘
-        >>> nw.to_native(df4)
-        shape: (2, 2)
-        ┌──────┬──────┐
-        │ col1 ┆ col2 │
-        │ ---  ┆ ---  │
-        │ f32  ┆ i64  │
-        ╞══════╪══════╡
-        │ 1.0  ┆ 3    │
-        │ 2.0  ┆ 4    │
-        └──────┴──────┘
-
-        Constructing a DataFrame from a numpy ndarray, specifying column names:
-
-        >>> import numpy as np
-        >>> data = np.array([(1, 2), (3, 4)], dtype=np.int64)
-        >>> df_pl5 = pl.DataFrame(data, schema=["a", "b"], orient="col")
-        >>> df5 = nw.DataFrame(df_pl5)
-        >>> df5
-        ┌─────────────────────────────────────────────────┐
-        | Narwhals DataFrame                              |
-        | Use `narwhals.to_native()` to see native output |
-        └─────────────────────────────────────────────────┘
-        >>> nw.to_native(df5)
-        shape: (2, 2)
-        ┌─────┬─────┐
-        │ a   ┆ b   │
-        │ --- ┆ --- │
-        │ i64 ┆ i64 │
-        ╞═════╪═════╡
-        │ 1   ┆ 3   │
-        │ 2   ┆ 4   │
-        └─────┴─────┘
-
-        Constructing a DataFrame from a list of lists, row orientation inferred:
-
-        >>> data = [[1, 2, 3], [4, 5, 6]]
-        >>> df_pl6 = pl.DataFrame(data, schema=["a", "b", "c"])
-        >>> df6 = nw.DataFrame(df_pl6)
-        >>> df6
-        ┌─────────────────────────────────────────────────┐
-        | Narwhals DataFrame                              |
-        | Use `narwhals.to_native()` to see native output |
-        └─────────────────────────────────────────────────┘
-        >>> nw.to_native(df6)
-        shape: (2, 3)
-        ┌─────┬─────┬─────┐
-        │ a   ┆ b   ┆ c   │
-        │ --- ┆ --- ┆ --- │
-        │ i64 ┆ i64 ┆ i64 │
-        ╞═════╪═════╪═════╡
-        │ 1   ┆ 2   ┆ 3   │
-        │ 4   ┆ 5   ┆ 6   │
-        └─────┴─────┴─────┘
     """
 
     def __init__(
@@ -481,15 +371,9 @@ class DataFrame(BaseFrame):
             │ 4   ┆ apple  ┆ 2   ┆ beetle ┆ 2        │
             │ 5   ┆ banana ┆ 1   ┆ beetle ┆ -30      │
             └─────┴────────┴─────┴────────┴──────────┘
-            >>> import pprint
-            >>> pprint.pprint(df.to_dict(as_series=False))
-            {'A': [1, 2, 3, 4, 5],
-             'B': [5, 4, 3, 2, 1],
-             'cars': ['beetle', 'audi', 'beetle', 'beetle', 'beetle'],
-             'fruits': ['banana', 'banana', 'apple', 'apple', 'banana'],
-             'optional': [28, 300, None, 2, -30]}
-            >>> p = pprint.pformat(df.to_dict(as_series=True)).replace('\t', '    ')
-            >>> print(p)
+            >>> df.to_dict(as_series=False)
+            {'A': [1, 2, 3, 4, 5], 'fruits': ['banana', 'banana', 'apple', 'apple', 'banana'], 'B': [5, 4, 3, 2, 1], 'cars': ['beetle', 'audi', 'beetle', 'beetle', 'beetle'], 'optional': [28, 300, None, 2, -30]}
+            >>> df.to_dict(as_series=True) # doctest: +SKIP
             {'A': shape: (5,)
             Series: 'A' [i64]
             [
@@ -498,26 +382,7 @@ class DataFrame(BaseFrame):
                 3
                 4
                 5
-            ],
-             'B': shape: (5,)
-            Series: 'B' [i64]
-            [
-                5
-                4
-                3
-                2
-                1
-            ],
-             'cars': shape: (5,)
-            Series: 'cars' [str]
-            [
-                "beetle"
-                "audi"
-                "beetle"
-                "beetle"
-                "beetle"
-            ],
-             'fruits': shape: (5,)
+            ], 'fruits': shape: (5,)
             Series: 'fruits' [str]
             [
                 "banana"
@@ -525,8 +390,23 @@ class DataFrame(BaseFrame):
                 "apple"
                 "apple"
                 "banana"
-            ],
-             'optional': shape: (5,)
+            ], 'B': shape: (5,)
+            Series: 'B' [i64]
+            [
+                5
+                4
+                3
+                2
+                1
+            ], 'cars': shape: (5,)
+            Series: 'cars' [str]
+            [
+                "beetle"
+                "audi"
+                "beetle"
+                "beetle"
+                "beetle"
+            ], 'optional': shape: (5,)
             Series: 'optional' [i64]
             [
                 28

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -389,6 +389,37 @@ class DataFrame(BaseFrame):
         return self._dataframe.to_pandas()
 
     def to_numpy(self) -> Any:
+        r"""
+        Convert this DataFrame to a NumPy ndarray.
+
+        Returns:
+            A NumPy ndarray.
+
+        Examples:
+            >>> import polars as pl
+            >>> import narwhals as nw
+            >>> df_pl = pl.DataFrame(
+            ...     {
+            ...         "foo": [1, 2, 3],
+            ...         "bar": [6.5, 7.0, 8.5],
+            ...         "ham": ["a", "b", "c"],
+            ...     },
+            ...     schema_overrides={"foo": pl.UInt8, "bar": pl.Float32},
+            ... )
+            >>> df = nw.DataFrame(df_pl)
+            >>> df
+            ┌─────────────────────────────────────────────────┐
+            | Narwhals DataFrame                              |
+            | Use `narwhals.to_native()` to see native output |
+            └─────────────────────────────────────────────────┘
+
+            Export to a standard 2D numpy array.
+
+            >>> df.to_numpy()
+            array([[1, 6.5, 'a'],
+                   [2, 7.0, 'b'],
+                   [3, 8.5, 'c']], dtype=object)
+        """
         return self._dataframe.to_numpy()
 
     @property
@@ -412,6 +443,99 @@ class DataFrame(BaseFrame):
         return Series(self._dataframe[col_name])
 
     def to_dict(self, *, as_series: bool = True) -> dict[str, Any]:
+        r"""
+        Convert DataFrame to a dictionary mapping column name to values.
+
+        Arguments:
+            as_series: If set to true ``True`` values are Series, otherwise
+                        values are Any.
+
+        Examples:
+            >>> import polars as pl
+            >>> import narwhals as nw
+            >>> df_pl = pl.DataFrame(
+            ...     {
+            ...         "A": [1, 2, 3, 4, 5],
+            ...         "fruits": ["banana", "banana", "apple", "apple", "banana"],
+            ...         "B": [5, 4, 3, 2, 1],
+            ...         "cars": ["beetle", "audi", "beetle", "beetle", "beetle"],
+            ...         "optional": [28, 300, None, 2, -30],
+            ...     }
+            ... )
+            >>> df = nw.DataFrame(df_pl)
+            >>> df
+            ┌─────────────────────────────────────────────────┐
+            | Narwhals DataFrame                              |
+            | Use `narwhals.to_native()` to see native output |
+            └─────────────────────────────────────────────────┘
+            >>> nw.to_native(df)
+            shape: (5, 5)
+            ┌─────┬────────┬─────┬────────┬──────────┐
+            │ A   ┆ fruits ┆ B   ┆ cars   ┆ optional │
+            │ --- ┆ ---    ┆ --- ┆ ---    ┆ ---      │
+            │ i64 ┆ str    ┆ i64 ┆ str    ┆ i64      │
+            ╞═════╪════════╪═════╪════════╪══════════╡
+            │ 1   ┆ banana ┆ 5   ┆ beetle ┆ 28       │
+            │ 2   ┆ banana ┆ 4   ┆ audi   ┆ 300      │
+            │ 3   ┆ apple  ┆ 3   ┆ beetle ┆ null     │
+            │ 4   ┆ apple  ┆ 2   ┆ beetle ┆ 2        │
+            │ 5   ┆ banana ┆ 1   ┆ beetle ┆ -30      │
+            └─────┴────────┴─────┴────────┴──────────┘
+            >>> import pprint
+            >>> pprint.pprint(df.to_dict(as_series=False))
+            {'A': [1, 2, 3, 4, 5],
+             'B': [5, 4, 3, 2, 1],
+             'cars': ['beetle', 'audi', 'beetle', 'beetle', 'beetle'],
+             'fruits': ['banana', 'banana', 'apple', 'apple', 'banana'],
+             'optional': [28, 300, None, 2, -30]}
+            >>> p = pprint.pformat(df.to_dict(as_series=True)).replace('\t', '    ')
+            >>> print(p)
+            {'A': shape: (5,)
+            Series: 'A' [i64]
+            [
+                1
+                2
+                3
+                4
+                5
+            ],
+             'B': shape: (5,)
+            Series: 'B' [i64]
+            [
+                5
+                4
+                3
+                2
+                1
+            ],
+             'cars': shape: (5,)
+            Series: 'cars' [str]
+            [
+                "beetle"
+                "audi"
+                "beetle"
+                "beetle"
+                "beetle"
+            ],
+             'fruits': shape: (5,)
+            Series: 'fruits' [str]
+            [
+                "banana"
+                "banana"
+                "apple"
+                "apple"
+                "banana"
+            ],
+             'optional': shape: (5,)
+            Series: 'optional' [i64]
+            [
+                28
+                300
+                null
+                2
+                -30
+            ]}
+        """
         return self._dataframe.to_dict(as_series=as_series)  # type: ignore[no-any-return]
 
     # inherited

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -157,6 +157,150 @@ class BaseFrame:
 
 
 class DataFrame(BaseFrame):
+    r"""
+    Two-dimensional data structure representing data as a table with rows and columns.
+
+    Arguments:
+        df: A pandas-like dataframe (Pandas, cuDF or Modin), a Polars dataframe,
+             a narwhals DataFrame or a narwhals LazyFrame.
+
+        is_polars: if set to `True`, assume the dataframe to be of Polars type.
+
+    Examples:
+        Constructing a DataFrame from a dictionary:
+
+        >>> import polars as pl
+        >>> import narwhals as nw
+        >>> data = {"a": [1, 2], "b": [3, 4]}
+        >>> df_pl = pl.DataFrame(data)
+        >>> df = nw.DataFrame(df_pl)
+        >>> df
+        ┌─────────────────────────────────────────────────┐
+        | Narwhals DataFrame                              |
+        | Use `narwhals.to_native()` to see native output |
+        └─────────────────────────────────────────────────┘
+        >>> nw.to_native(df)
+        shape: (2, 2)
+        ┌─────┬─────┐
+        │ a   ┆ b   │
+        │ --- ┆ --- │
+        │ i64 ┆ i64 │
+        ╞═════╪═════╡
+        │ 1   ┆ 3   │
+        │ 2   ┆ 4   │
+        └─────┴─────┘
+
+        To specify a more detailed/specific frame schema you can supply the `schema`
+        parameter with a dictionary of (name,dtype) pairs...
+
+        >>> data = {"col1": [0, 2], "col2": [3, 7]}
+        >>> df_pl2 = pl.DataFrame(data, schema={"col1": pl.Float32, "col2": pl.Int64})
+        >>> df2 = nw.DataFrame(df_pl2)
+        >>> df2
+        ┌─────────────────────────────────────────────────┐
+        | Narwhals DataFrame                              |
+        | Use `narwhals.to_native()` to see native output |
+        └─────────────────────────────────────────────────┘
+        >>> nw.to_native(df2)
+        shape: (2, 2)
+        ┌──────┬──────┐
+        │ col1 ┆ col2 │
+        │ ---  ┆ ---  │
+        │ f32  ┆ i64  │
+        ╞══════╪══════╡
+        │ 0.0  ┆ 3    │
+        │ 2.0  ┆ 7    │
+        └──────┴──────┘
+
+        ...a sequence of (name,dtype) pairs...
+
+        >>> data = {"col1": [1, 2], "col2": [3, 4]}
+        >>> df_pl3 = pl.DataFrame(data, schema=[("col1", pl.Float32), ("col2", pl.Int64)])
+        >>> df3 = nw.DataFrame(df_pl3)
+        >>> df3
+        ┌─────────────────────────────────────────────────┐
+        | Narwhals DataFrame                              |
+        | Use `narwhals.to_native()` to see native output |
+        └─────────────────────────────────────────────────┘
+        >>> nw.to_native(df3)
+        shape: (2, 2)
+        ┌──────┬──────┐
+        │ col1 ┆ col2 │
+        │ ---  ┆ ---  │
+        │ f32  ┆ i64  │
+        ╞══════╪══════╡
+        │ 1.0  ┆ 3    │
+        │ 2.0  ┆ 4    │
+        └──────┴──────┘
+
+        ...or a list of typed Series.
+
+        >>> data = [
+        ...     pl.Series("col1", [1, 2], dtype=pl.Float32),
+        ...     pl.Series("col2", [3, 4], dtype=pl.Int64),
+        ... ]
+        >>> df_pl4 = pl.DataFrame(data)
+        >>> df4 = nw.DataFrame(df_pl4)
+        >>> df4
+        ┌─────────────────────────────────────────────────┐
+        | Narwhals DataFrame                              |
+        | Use `narwhals.to_native()` to see native output |
+        └─────────────────────────────────────────────────┘
+        >>> nw.to_native(df4)
+        shape: (2, 2)
+        ┌──────┬──────┐
+        │ col1 ┆ col2 │
+        │ ---  ┆ ---  │
+        │ f32  ┆ i64  │
+        ╞══════╪══════╡
+        │ 1.0  ┆ 3    │
+        │ 2.0  ┆ 4    │
+        └──────┴──────┘
+
+        Constructing a DataFrame from a numpy ndarray, specifying column names:
+
+        >>> import numpy as np
+        >>> data = np.array([(1, 2), (3, 4)], dtype=np.int64)
+        >>> df_pl5 = pl.DataFrame(data, schema=["a", "b"], orient="col")
+        >>> df5 = nw.DataFrame(df_pl5)
+        >>> df5
+        ┌─────────────────────────────────────────────────┐
+        | Narwhals DataFrame                              |
+        | Use `narwhals.to_native()` to see native output |
+        └─────────────────────────────────────────────────┘
+        >>> nw.to_native(df5)
+        shape: (2, 2)
+        ┌─────┬─────┐
+        │ a   ┆ b   │
+        │ --- ┆ --- │
+        │ i64 ┆ i64 │
+        ╞═════╪═════╡
+        │ 1   ┆ 3   │
+        │ 2   ┆ 4   │
+        └─────┴─────┘
+
+        Constructing a DataFrame from a list of lists, row orientation inferred:
+
+        >>> data = [[1, 2, 3], [4, 5, 6]]
+        >>> df_pl6 = pl.DataFrame(data, schema=["a", "b", "c"])
+        >>> df6 = nw.DataFrame(df_pl6)
+        >>> df6
+        ┌─────────────────────────────────────────────────┐
+        | Narwhals DataFrame                              |
+        | Use `narwhals.to_native()` to see native output |
+        └─────────────────────────────────────────────────┘
+        >>> nw.to_native(df6)
+        shape: (2, 3)
+        ┌─────┬─────┬─────┐
+        │ a   ┆ b   ┆ c   │
+        │ --- ┆ --- ┆ --- │
+        │ i64 ┆ i64 ┆ i64 │
+        ╞═════╪═════╪═════╡
+        │ 1   ┆ 2   ┆ 3   │
+        │ 4   ┆ 5   ┆ 6   │
+        └─────┴─────┴─────┘
+    """
+
     def __init__(
         self,
         df: Any,
@@ -186,7 +330,7 @@ class DataFrame(BaseFrame):
         ):  # pragma: no cover
             self._dataframe = PandasDataFrame(df, implementation="cudf")
         else:
-            msg = f"Expected pandas-like dataframe, Polars dataframe, or Polars lazyframe, got: {type(df)}"
+            msg = f"Expected pandas-like dataframe, or Polars dataframe, got: {type(df)}"
             raise TypeError(msg)
 
     def to_pandas(self) -> Any:


### PR DESCRIPTION
This PR adds all the missing docstrings for the `narwhals.dataframe.DataFrame` class.

## Docstring problem

I had to use some tricks to let one of the `to_dict()` docstrings pass. I think there is a problem in the docstring "translation" process. Apparently tabs in the outputs are transformed to spaces before the output is checked by pytest. However, even setting the output to have spaces instead of tabs does not work. My workaround is to transform the tabs to spaces like this:

```python
p = pprint.pformat(df.to_dict(as_series=True)).replace('\t', '    ')
print(p)
```

instead of doing directly:

```python
df.to_dict(as_series=True)
```

The other solution would be just to skip the test with `# doctest: +SKIP`

## Error message

~~I changed the error message in the `__init__` because the class constructor should not accept Polars lazy frames.~~

Change reverted because of failing tests, but it seems sensible to me.