### PR TITLE
Docstrings LazyFrame

### DIFF
--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -1028,6 +1028,47 @@ class LazyFrame(BaseFrame):
             raise TypeError(msg)
 
     def collect(self) -> DataFrame:
+        r"""
+        Materialize this LazyFrame into a DataFrame.
+
+
+        Returns:
+            DataFrame
+
+        Examples:
+            >>> import polars as pl
+            >>> import narwhals as nw
+            >>> lf_pl = pl.LazyFrame(
+            ...     {
+            ...         "a": ["a", "b", "a", "b", "b", "c"],
+            ...         "b": [1, 2, 3, 4, 5, 6],
+            ...         "c": [6, 5, 4, 3, 2, 1],
+            ...     }
+            ... )
+            >>> lf = nw.LazyFrame(lf_pl)
+            >>> lf
+            ┌─────────────────────────────────────────────────┐
+            | Narwhals DataFrame                              |
+            | Use `narwhals.to_native()` to see native output |
+            └─────────────────────────────────────────────────┘
+            >>> df = lf.group_by("a").agg(nw.all().sum()).collect()
+            >>> df
+            ┌─────────────────────────────────────────────────┐
+            | Narwhals DataFrame                              |
+            | Use `narwhals.to_native()` to see native output |
+            └─────────────────────────────────────────────────┘
+            >>> nw.to_native(df).sort("a")
+            shape: (3, 3)
+            ┌─────┬─────┬─────┐
+            │ a   ┆ b   ┆ c   │
+            │ --- ┆ --- ┆ --- │
+            │ str ┆ i64 ┆ i64 │
+            ╞═════╪═════╪═════╡
+            │ a   ┆ 4   ┆ 10  │
+            │ b   ┆ 11  ┆ 10  │
+            │ c   ┆ 6   ┆ 1   │
+            └─────┴─────┴─────┘
+        """
         return DataFrame(
             self._dataframe.collect(),
         )

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -1152,23 +1152,6 @@ class LazyFrame(BaseFrame):
             │ 2     ┆ 7   ┆ b   │
             │ 3     ┆ 8   ┆ c   │
             └───────┴─────┴─────┘
-            >>> lframe = lf.rename(lambda column_name: "c" + column_name[1:]).collect()
-            >>> lframe
-            ┌─────────────────────────────────────────────────┐
-            | Narwhals DataFrame                              |
-            | Use `narwhals.to_native()` to see native output |
-            └─────────────────────────────────────────────────┘
-            >>> nw.to_native(lframe)
-            shape: (3, 3)
-            ┌─────┬─────┬─────┐
-            │ coo ┆ car ┆ cam │
-            │ --- ┆ --- ┆ --- │
-            │ i64 ┆ i64 ┆ str │
-            ╞═════╪═════╪═════╡
-            │ 1   ┆ 6   ┆ a   │
-            │ 2   ┆ 7   ┆ b   │
-            │ 3   ┆ 8   ┆ c   │
-            └─────┴─────┴─────┘
         """
         return super().rename(mapping)
 
@@ -1178,12 +1161,6 @@ class LazyFrame(BaseFrame):
 
         Arguments:
             n: Number of rows to return.
-
-        Notes:
-            Consider using the `fetch` operation if you only want to test
-             your query. The `fetch` operation will load the first `n`
-             rows at the scan level, whereas the `head`/`limit` are
-             applied at the end.
 
         Examples:
             >>> import polars as pl
@@ -1271,27 +1248,6 @@ class LazyFrame(BaseFrame):
             │ 2   ┆ 7.0 │
             │ 3   ┆ 8.0 │
             └─────┴─────┘
-
-            Drop multiple columns by passing a selector.
-
-            >>> import polars.selectors as cs
-            >>> lframe = lf.drop(cs.numeric()).collect()
-            >>> lframe
-            ┌─────────────────────────────────────────────────┐
-            | Narwhals DataFrame                              |
-            | Use `narwhals.to_native()` to see native output |
-            └─────────────────────────────────────────────────┘
-            >>> nw.to_native(lframe)
-            shape: (3, 1)
-            ┌─────┐
-            │ ham │
-            │ --- │
-            │ str │
-            ╞═════╡
-            │ a   │
-            │ b   │
-            │ c   │
-            └─────┘
 
             Use positional arguments to drop multiple columns.
 

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -1031,7 +1031,6 @@ class LazyFrame(BaseFrame):
         r"""
         Materialize this LazyFrame into a DataFrame.
 
-
         Returns:
             DataFrame
 
@@ -1076,6 +1075,23 @@ class LazyFrame(BaseFrame):
     # inherited
     @property
     def schema(self) -> dict[str, DType]:
+        r"""
+        Get a dict[column name, DType].
+
+        Examples:
+            >>> import polars as pl
+            >>> import narwhals as nw
+            >>> lf_pl = pl.LazyFrame(
+            ...     {
+            ...         "foo": [1, 2, 3],
+            ...         "bar": [6.0, 7.0, 8.0],
+            ...         "ham": ["a", "b", "c"],
+            ...     }
+            ... )
+            >>> lf = nw.LazyFrame(lf_pl)
+            >>> lf.schema # doctest: +SKIP
+            OrderedDict({'foo': Int64, 'bar': Float64, 'ham': String})
+        """
         return super().schema
 
     @property
@@ -1095,6 +1111,65 @@ class LazyFrame(BaseFrame):
         return super().select(*exprs, **named_exprs)
 
     def rename(self, mapping: dict[str, str]) -> Self:
+        r"""
+        Rename column names.
+
+        Arguments:
+            mapping: Key value pairs that map from old name to new name, or a
+                      function that takes the old name as input and returns the
+                      new name.
+
+        Notes:
+            If existing names are swapped (e.g. 'A' points to 'B' and 'B'
+             points to 'A'), polars will block projection and predicate
+             pushdowns at this node.
+
+        Examples:
+            >>> import polars as pl
+            >>> import narwhals as nw
+            >>> lf_pl = pl.LazyFrame(
+            ...     {
+            ...         "foo": [1, 2, 3],
+            ...         "bar": [6, 7, 8],
+            ...         "ham": ["a", "b", "c"],
+            ...     }
+            ... )
+            >>> lf = nw.LazyFrame(lf_pl)
+            >>> lframe = lf.rename({"foo": "apple"}).collect()
+            >>> lframe
+            ┌─────────────────────────────────────────────────┐
+            | Narwhals DataFrame                              |
+            | Use `narwhals.to_native()` to see native output |
+            └─────────────────────────────────────────────────┘
+            >>> nw.to_native(lframe)
+            shape: (3, 3)
+            ┌───────┬─────┬─────┐
+            │ apple ┆ bar ┆ ham │
+            │ ---   ┆ --- ┆ --- │
+            │ i64   ┆ i64 ┆ str │
+            ╞═══════╪═════╪═════╡
+            │ 1     ┆ 6   ┆ a   │
+            │ 2     ┆ 7   ┆ b   │
+            │ 3     ┆ 8   ┆ c   │
+            └───────┴─────┴─────┘
+            >>> lframe = lf.rename(lambda column_name: "c" + column_name[1:]).collect()
+            >>> lframe
+            ┌─────────────────────────────────────────────────┐
+            | Narwhals DataFrame                              |
+            | Use `narwhals.to_native()` to see native output |
+            └─────────────────────────────────────────────────┘
+            >>> nw.to_native(lframe)
+            shape: (3, 3)
+            ┌─────┬─────┬─────┐
+            │ coo ┆ car ┆ cam │
+            │ --- ┆ --- ┆ --- │
+            │ i64 ┆ i64 ┆ str │
+            ╞═════╪═════╪═════╡
+            │ 1   ┆ 6   ┆ a   │
+            │ 2   ┆ 7   ┆ b   │
+            │ 3   ┆ 8   ┆ c   │
+            └─────┴─────┴─────┘
+        """
         return super().rename(mapping)
 
     def head(self, n: int) -> Self:

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -1173,9 +1173,146 @@ class LazyFrame(BaseFrame):
         return super().rename(mapping)
 
     def head(self, n: int) -> Self:
+        r"""
+        Get the first `n` rows.
+
+        Arguments:
+            n: Number of rows to return.
+
+        Notes:
+            Consider using the `fetch` operation if you only want to test
+             your query. The `fetch` operation will load the first `n`
+             rows at the scan level, whereas the `head`/`limit` are
+             applied at the end.
+
+        Examples:
+            >>> import polars as pl
+            >>> import narwhals as nw
+            >>> lf_pl = pl.LazyFrame(
+            ...     {
+            ...         "a": [1, 2, 3, 4, 5, 6],
+            ...         "b": [7, 8, 9, 10, 11, 12],
+            ...     }
+            ... )
+            >>> lf = nw.LazyFrame(lf_pl)
+            >>> lframe = lf.head(5).collect()
+            >>> lframe
+            ┌─────────────────────────────────────────────────┐
+            | Narwhals DataFrame                              |
+            | Use `narwhals.to_native()` to see native output |
+            └─────────────────────────────────────────────────┘
+            >>> nw.to_native(lframe)
+            shape: (5, 2)
+            ┌─────┬─────┐
+            │ a   ┆ b   │
+            │ --- ┆ --- │
+            │ i64 ┆ i64 │
+            ╞═════╪═════╡
+            │ 1   ┆ 7   │
+            │ 2   ┆ 8   │
+            │ 3   ┆ 9   │
+            │ 4   ┆ 10  │
+            │ 5   ┆ 11  │
+            └─────┴─────┘
+            >>> lframe = lf.head(2).collect()
+            >>> lframe
+            ┌─────────────────────────────────────────────────┐
+            | Narwhals DataFrame                              |
+            | Use `narwhals.to_native()` to see native output |
+            └─────────────────────────────────────────────────┘
+            >>> nw.to_native(lframe)
+            shape: (2, 2)
+            ┌─────┬─────┐
+            │ a   ┆ b   │
+            │ --- ┆ --- │
+            │ i64 ┆ i64 │
+            ╞═════╪═════╡
+            │ 1   ┆ 7   │
+            │ 2   ┆ 8   │
+            └─────┴─────┘
+        """
         return super().head(n)
 
     def drop(self, *columns: str | Iterable[str]) -> Self:
+        r"""
+        Remove columns from the LazyFrame.
+
+        Arguments:
+            *columns: Names of the columns that should be removed from the
+                      dataframe. Accepts column selector input.
+
+        Examples:
+            Drop a single column by passing the name of that column.
+
+            >>> import polars as pl
+            >>> import narwhals as nw
+            >>> lf_pl = pl.LazyFrame(
+            ...     {
+            ...         "foo": [1, 2, 3],
+            ...         "bar": [6.0, 7.0, 8.0],
+            ...         "ham": ["a", "b", "c"],
+            ...     }
+            ... )
+            >>> lf = nw.LazyFrame(lf_pl)
+            >>> lframe = lf.drop("ham").collect()
+            >>> lframe
+            ┌─────────────────────────────────────────────────┐
+            | Narwhals DataFrame                              |
+            | Use `narwhals.to_native()` to see native output |
+            └─────────────────────────────────────────────────┘
+            >>> nw.to_native(lframe)
+            shape: (3, 2)
+            ┌─────┬─────┐
+            │ foo ┆ bar │
+            │ --- ┆ --- │
+            │ i64 ┆ f64 │
+            ╞═════╪═════╡
+            │ 1   ┆ 6.0 │
+            │ 2   ┆ 7.0 │
+            │ 3   ┆ 8.0 │
+            └─────┴─────┘
+
+            Drop multiple columns by passing a selector.
+
+            >>> import polars.selectors as cs
+            >>> lframe = lf.drop(cs.numeric()).collect()
+            >>> lframe
+            ┌─────────────────────────────────────────────────┐
+            | Narwhals DataFrame                              |
+            | Use `narwhals.to_native()` to see native output |
+            └─────────────────────────────────────────────────┘
+            >>> nw.to_native(lframe)
+            shape: (3, 1)
+            ┌─────┐
+            │ ham │
+            │ --- │
+            │ str │
+            ╞═════╡
+            │ a   │
+            │ b   │
+            │ c   │
+            └─────┘
+
+            Use positional arguments to drop multiple columns.
+
+            >>> lframe = lf.drop("foo", "ham").collect()
+            >>> lframe
+            ┌─────────────────────────────────────────────────┐
+            | Narwhals DataFrame                              |
+            | Use `narwhals.to_native()` to see native output |
+            └─────────────────────────────────────────────────┘
+            >>> nw.to_native(lframe)
+            shape: (3, 1)
+            ┌─────┐
+            │ bar │
+            │ --- │
+            │ f64 │
+            ╞═════╡
+            │ 6.0 │
+            │ 7.0 │
+            │ 8.0 │
+            └─────┘
+        """
         return super().drop(*columns)
 
     def unique(self, subset: str | list[str]) -> Self:


### PR DESCRIPTION
I added the missing docstrings for the `narwhals.dataframe.LazyFrame` class.

The pre-commit error is for a single word in a docstring output. Codespell thinks it's a typo. I tried adding an inline ignore but it doesn't work.

About the other error in the CI, I think the docstring with the lambda operator is not supported in Python 3.8.