### PR TITLE
Bumped polars version on extremes.yml due to polars old bug

### DIFF
--- a/.github/workflows/extremes.yml
+++ b/.github/workflows/extremes.yml
@@ -29,7 +29,7 @@ jobs:
       - name: install-reqs
         run: python -m pip install --upgrade tox virtualenv setuptools pip -r requirements-dev.txt
       - name: install-modin
-        run: python -m pip install pandas==2.0.0 polars==0.20.5 modin[dask]
+        run: python -m pip install pandas==2.0.0 polars==0.20.13 modin[dask]
       - name: Run pytest
         run: pytest tests --cov=narwhals --cov=tests --cov-fail-under=50
       - name: Run doctests

--- a/tests/hypothesis/test_join.py
+++ b/tests/hypothesis/test_join.py
@@ -10,11 +10,7 @@ from pandas.testing import assert_frame_equal
 import narwhals as nw
 
 
-<<<<<<< HEAD
 @example([0, 0, 0], [0, 0, 0], [0.0, 0.0, -0.0], ["c"])  # type: ignore[misc]
-=======
-@example([0, 0, 0], [0, 0, 0], [0.0, 0.0, -0.0], ["c"])
->>>>>>> origin/error
 @given(
     st.lists(
         st.integers(min_value=-9223372036854775807, max_value=9223372036854775807),

--- a/tests/hypothesis/test_join.py
+++ b/tests/hypothesis/test_join.py
@@ -2,13 +2,15 @@ from __future__ import annotations
 
 import pandas as pd
 import polars as pl
-from hypothesis import given, example
+from hypothesis import example
+from hypothesis import given
 from hypothesis import strategies as st
 from pandas.testing import assert_frame_equal
 
 import narwhals as nw
 
-@example([0, 0, 0], [0, 0, 0], [0.0, 0.0, -0.0], ["c"])
+
+@example([0, 0, 0], [0, 0, 0], [0.0, 0.0, -0.0], ["c"])  # type: ignore[misc]
 @given(
     st.lists(
         st.integers(min_value=-9223372036854775807, max_value=9223372036854775807),

--- a/tests/hypothesis/test_join.py
+++ b/tests/hypothesis/test_join.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import pandas as pd
 import polars as pl
-from hypothesis import given
+from hypothesis import given, example
 from hypothesis import strategies as st
 from pandas.testing import assert_frame_equal
 
 import narwhals as nw
 
-
+@example([0, 0, 0], [0, 0, 0], [0.0, 0.0, -0.0], ["c"])
 @given(
     st.lists(
         st.integers(min_value=-9223372036854775807, max_value=9223372036854775807),


### PR DESCRIPTION
Previous polars versions were failing when using `join` on a column with a `float=-0.0`.

Added specific example to make sure it is always tested. 