### PR TITLE
provide more context in ibis comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,12 @@ There are three steps to writing dataframe-agnostic code using Narwhals:
 
 ## Package size
 
-At only 0.3 MB and with **zero** dependencies, Narwhals is about as lightweight as it gets. Here's a comparison
-with Ibis (though note that the two projects have different goals and are not in competition):
+Like Ibis, Narwhals aims to enable dataframe-agnostic code. However, Narwhals comes with **zero** dependencies,
+is about as lightweight as it gets, and is aimed at library developers rather than at end users. It also does
+not aim to support as many backends, preferring to instead focus on dataframes.
+
+The projects are not in competition, and the comparison is intended only to help you choose the right tool
+for the right task.
 
 <h1 align="center">
 	<img


### PR DESCRIPTION
providing a bit more context for the comparison

I think this still needs showing though, as for the use case I have in mind, requiring pandas+PyArrow is a non-starter

can always remove the plot if they do follow through on making PyArrow+pandas optional