### PR TITLE
preserve object dtype

### DIFF
--- a/narwhals/_pandas_like/utils.py
+++ b/narwhals/_pandas_like/utils.py
@@ -312,11 +312,7 @@ def translate_dtype(dtype: Any) -> DType:
     if str(dtype).startswith("datetime64"):
         # todo: different time units and time zones
         return dtypes.Datetime()
-    if dtype == "object":  # pragma: no cover
-        import pandas as pd
-
-        assert parse_version(pd.__version__) < parse_version("2.0.0")
-        # Should only happen for pandas pre 2.0.0
+    if dtype == "object":
         return dtypes.String()
     msg = f"Unknown dtype: {dtype}"  # pragma: no cover
     raise AssertionError(msg)

--- a/tests/hypothesis/test_basic_arithmetic.py
+++ b/tests/hypothesis/test_basic_arithmetic.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pandas as pd
 import polars as pl
+import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 from numpy.testing import assert_allclose
@@ -21,6 +22,7 @@ import narwhals as nw
         max_size=3,
     ),
 )  # type: ignore[misc]
+@pytest.mark.slow()
 def test_mean(
     integer: st.SearchStrategy[list[int]],
     floats: st.SearchStrategy[float],


### PR DESCRIPTION
we shouldn't be converting to a proper string dtype on the user's behalf, just preserve what they already have

"proper" Object support may come later, if there's requests - but for now, treat them as strings in disguise