### PR TITLE
make pandas>=1.1.5 the minimum requirement

### DIFF
--- a/.github/workflows/extremes.yml
+++ b/.github/workflows/extremes.yml
@@ -29,7 +29,7 @@ jobs:
       - name: install-reqs
         run: python -m pip install --upgrade tox virtualenv setuptools pip -r requirements-dev.txt
       - name: install-modin
-        run: python -m pip install pandas==1.2.0 polars==0.20.3
+        run: python -m pip install pandas==1.1.5 polars==0.20.3
       - name: Run pytest
         run: pytest tests --cov=narwhals --cov=tests --cov-fail-under=50 --runslow
       - name: Run doctests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-pandas = ["pandas>=1.2.0"]
+pandas = ["pandas>=1.1.5"]
 polars = ["polars>=0.20.3"]
 
 [project.urls]
@@ -87,7 +87,6 @@ plugins = ["covdefaults"]
 exclude_also = [
   "> POLARS_VERSION",
   "if sys.version_info() <",
-  'if df_raw is None:',
 ]
 
 [tool.mypy]

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -16,15 +16,6 @@ from narwhals.utils import parse_version
 from tests.utils import compare_dicts
 
 df_pandas = pd.DataFrame({"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]})
-df_pandas_nullable = pd.DataFrame(
-    {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
-).astype(
-    {
-        "a": "Int64",
-        "b": "Int64",
-        "z": "Float64",
-    }
-)
 if parse_version(pd.__version__) >= parse_version("1.5.0"):
     df_pandas_pyarrow = pd.DataFrame(
         {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
@@ -35,8 +26,18 @@ if parse_version(pd.__version__) >= parse_version("1.5.0"):
             "z": "Float64[pyarrow]",
         }
     )
+    df_pandas_nullable = pd.DataFrame(
+        {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    ).astype(
+        {
+            "a": "Int64",
+            "b": "Int64",
+            "z": "Float64",
+        }
+    )
 else:  # pragma: no cover
-    df_pandas_pyarrow = None
+    df_pandas_pyarrow = df_pandas
+    df_pandas_nullable = df_pandas
 df_polars = pl.DataFrame({"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]})
 df_lazy = pl.LazyFrame({"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]})
 df_pandas_na = pd.DataFrame({"a": [None, 3, 2], "b": [4, 4, 6], "z": [7.0, None, 9]})
@@ -64,8 +65,6 @@ else:  # pragma: no cover
     [df_pandas, df_polars, df_lazy, df_pandas_nullable, df_pandas_pyarrow],
 )
 def test_sort(df_raw: Any) -> None:
-    if df_raw is None:
-        return
     df = nw.LazyFrame(df_raw)
     result = df.sort("a", "b")
     result_native = nw.to_native(result)
@@ -90,8 +89,6 @@ def test_sort(df_raw: Any) -> None:
     [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow],
 )
 def test_filter(df_raw: Any) -> None:
-    if df_raw is None:
-        return
     df = nw.LazyFrame(df_raw)
     result = df.filter(nw.col("a") > 1)
     result_native = nw.to_native(result)
@@ -116,8 +113,6 @@ def test_filter_series(df_raw: Any) -> None:
     [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow],
 )
 def test_add(df_raw: Any) -> None:
-    if df_raw is None:
-        return
     df = nw.LazyFrame(df_raw)
     result = df.with_columns(
         c=nw.col("a") + nw.col("b"),
@@ -141,8 +136,6 @@ def test_add(df_raw: Any) -> None:
     [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow],
 )
 def test_double(df_raw: Any) -> None:
-    if df_raw is None:
-        return
     df = nw.LazyFrame(df_raw)
     result = df.with_columns(nw.all() * 2)
     result_native = nw.to_native(result)
@@ -159,8 +152,6 @@ def test_double(df_raw: Any) -> None:
     [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow],
 )
 def test_select(df_raw: Any) -> None:
-    if df_raw is None:
-        return
     df = nw.LazyFrame(df_raw)
     result = df.select("a")
     result_native = nw.to_native(result)
@@ -186,8 +177,6 @@ def test_sumh(df_raw: Any) -> None:
     "df_raw", [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow]
 )
 def test_sumh_literal(df_raw: Any) -> None:
-    if df_raw is None:
-        return
     df = nw.LazyFrame(df_raw)
     result = df.with_columns(horizonal_sum=nw.sum_horizontal("a", nw.col("b")))
     result_native = nw.to_native(result)
@@ -204,8 +193,6 @@ def test_sumh_literal(df_raw: Any) -> None:
     "df_raw", [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow]
 )
 def test_sum_all(df_raw: Any) -> None:
-    if df_raw is None:
-        return
     df = nw.LazyFrame(df_raw)
     result = df.select(nw.all().sum())
     result_native = nw.to_native(result)
@@ -217,8 +204,6 @@ def test_sum_all(df_raw: Any) -> None:
     "df_raw", [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow]
 )
 def test_double_selected(df_raw: Any) -> None:
-    if df_raw is None:
-        return
     df = nw.LazyFrame(df_raw)
     result = df.select(nw.col("a", "b") * 2)
     result_native = nw.to_native(result)
@@ -238,8 +223,6 @@ def test_double_selected(df_raw: Any) -> None:
     "df_raw", [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow]
 )
 def test_rename(df_raw: Any) -> None:
-    if df_raw is None:
-        return
     df = nw.LazyFrame(df_raw)
     result = df.rename({"a": "x", "b": "y"})
     result_native = nw.to_native(result)
@@ -251,8 +234,6 @@ def test_rename(df_raw: Any) -> None:
     "df_raw", [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow]
 )
 def test_join(df_raw: Any) -> None:
-    if df_raw is None:
-        return
     df = nw.LazyFrame(df_raw)
     df_right = df
     result = df.join(df_right, left_on=["a", "b"], right_on=["a", "b"], how="inner")
@@ -279,8 +260,6 @@ def test_join(df_raw: Any) -> None:
     "df_raw", [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow]
 )
 def test_schema(df_raw: Any) -> None:
-    if df_raw is None:
-        return
     result = nw.LazyFrame(df_raw).schema
     expected = {"a": nw.Int64, "b": nw.Int64, "z": nw.Float64}
     assert result == expected
@@ -299,8 +278,6 @@ def test_schema(df_raw: Any) -> None:
     "df_raw", [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow]
 )
 def test_columns(df_raw: Any) -> None:
-    if df_raw is None:
-        return
     df = nw.LazyFrame(df_raw)
     result = df.columns
     expected = ["a", "b", "z"]
@@ -360,8 +337,6 @@ def test_convert_pandas(df_raw: Any) -> None:
     r"ignore:np\.find_common_type is deprecated\.:DeprecationWarning"
 )
 def test_convert_numpy(df_raw: Any) -> None:
-    if df_raw is None:
-        return
     result = nw.DataFrame(df_raw).to_numpy()
     expected = np.array([[1, 3, 2], [4, 4, 6], [7.0, 8, 9]]).T
     np.testing.assert_array_equal(result, expected)
@@ -487,8 +462,6 @@ def test_expr_na(df_raw: Any) -> None:
     "df_raw", [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow]
 )
 def test_head(df_raw: Any) -> None:
-    if df_raw is None:
-        return
     df = nw.LazyFrame(df_raw)
     result = nw.to_native(df.head(2))
     expected = {"a": [1, 3], "b": [4, 4], "z": [7.0, 8.0]}
@@ -502,8 +475,6 @@ def test_head(df_raw: Any) -> None:
     "df_raw", [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow]
 )
 def test_unique(df_raw: Any) -> None:
-    if df_raw is None:
-        return
     df = nw.LazyFrame(df_raw)
     result = nw.to_native(df.unique("b").sort("b"))
     expected = {"a": [1, 2], "b": [4, 6], "z": [7.0, 9.0]}
@@ -594,8 +565,6 @@ def test_to_dict() -> None:
     "df_raw", [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow]
 )
 def test_any_all(df_raw: Any) -> None:
-    if df_raw is None:
-        return
     df = nw.LazyFrame(df_raw)
     result = nw.to_native(df.select((nw.all() > 1).all()))
     expected = {"a": [False], "b": [True], "z": [True]}

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -8,6 +8,7 @@ import polars as pl
 import pytest
 
 import narwhals as nw
+from narwhals.utils import parse_version
 from tests.utils import compare_dicts
 
 df_pandas = pd.DataFrame(
@@ -15,18 +16,6 @@ df_pandas = pd.DataFrame(
         "a": [datetime(2020, 1, 1), datetime(2020, 1, 2), datetime(2020, 1, 3)],
         "b": [4, 4, 6],
         "z": [7.0, 8, 9],
-    }
-)
-df_pandas_nullable = pd.DataFrame(
-    {
-        "a": [datetime(2020, 1, 1), datetime(2020, 1, 2), datetime(2020, 1, 3)],
-        "b": [4, 4, 6],
-        "z": [7.0, 8, 9],
-    }
-).astype(
-    {
-        "b": "Int64",
-        "z": "Float64",
     }
 )
 df_polars = pl.DataFrame(
@@ -43,6 +32,21 @@ df_lazy = pl.LazyFrame(
         "z": [7.0, 8, 9],
     }
 )
+if parse_version(pd.__version__) >= parse_version("1.2.0"):
+    df_pandas_nullable = pd.DataFrame(
+        {
+            "a": [datetime(2020, 1, 1), datetime(2020, 1, 2), datetime(2020, 1, 3)],
+            "b": [4, 4, 6],
+            "z": [7.0, 8, 9],
+        }
+    ).astype(
+        {
+            "b": "Int64",
+            "z": "Float64",
+        }
+    )
+else:  # pragma: no cover
+    df_pandas_nullable = df_pandas
 
 
 @pytest.mark.parametrize("df_raw", [df_pandas, df_lazy, df_pandas_nullable])


### PR DESCRIPTION
we just need to skip some tests for the min-versions CI job, as Float64 wasn't available back then. But, anyone using pandas that far back wouldn't have been using Float64 anyway, so this won't affect them