### PR TITLE
perf: Use linked list for `ExprMetadata`

### DIFF
--- a/narwhals/_expression_parsing.py
+++ b/narwhals/_expression_parsing.py
@@ -412,58 +412,60 @@ class ExprMetadata:
     def from_node(  # noqa: PLR0911
         cls, node: ExprNode, *ces: CompliantExprAny
     ) -> ExprMetadata:
-        if node.kind is ExprKind.SERIES:
+        kind = node.kind
+        if kind is ExprKind.SERIES:
             return cls.from_selector_single(node)
-        if node.kind is ExprKind.COL:
+        if kind is ExprKind.COL:
             return (
-                ExprMetadata.from_selector_single(node)
+                cls.from_selector_single(node)
                 if len(node.kwargs["names"]) == 1
-                else ExprMetadata.from_selector_multi_named(node)
+                else cls.from_selector_multi_named(node)
             )
-        if node.kind is ExprKind.NTH:
+        if kind is ExprKind.NTH:
             return (
-                ExprMetadata.from_selector_single(node)
+                cls.from_selector_single(node)
                 if len(node.kwargs["indices"]) == 1
-                else ExprMetadata.from_selector_multi_unnamed(node)
+                else cls.from_selector_multi_unnamed(node)
             )
-        if node.kind in {ExprKind.ALL, ExprKind.EXCLUDE}:
-            return ExprMetadata.from_selector_multi_unnamed(node)
-        if node.kind is ExprKind.AGGREGATION:
-            return ExprMetadata.from_aggregation(node)
-        if node.kind is ExprKind.LITERAL:
-            return ExprMetadata.from_literal(node)
-        if node.kind is ExprKind.SELECTOR:
-            return ExprMetadata.from_selector_multi_unnamed(node)
-        if node.kind is ExprKind.ELEMENTWISE:
-            return ExprMetadata.from_elementwise(node, *ces)
-        msg = f"Unexpected node kind: {node.kind}"  # pragma: no cover
+        if kind in {ExprKind.ALL, ExprKind.EXCLUDE}:
+            return cls.from_selector_multi_unnamed(node)
+        if kind is ExprKind.AGGREGATION:
+            return cls.from_aggregation(node)
+        if kind is ExprKind.LITERAL:
+            return cls.from_literal(node)
+        if kind is ExprKind.SELECTOR:
+            return cls.from_selector_multi_unnamed(node)
+        if kind is ExprKind.ELEMENTWISE:
+            return cls.from_elementwise(node, *ces)
+        msg = f"Unexpected node kind: {kind}"  # pragma: no cover
         raise AssertionError(msg)  # pragma: no cover
 
     def with_node(  # noqa: PLR0911,C901
         self, node: ExprNode, ce: CompliantExprAny, *ces: CompliantExprAny
     ) -> ExprMetadata:
-        if node.kind is ExprKind.AGGREGATION:
+        kind = node.kind
+        if kind is ExprKind.AGGREGATION:
             return self.with_aggregation(node)
-        if node.kind is ExprKind.ELEMENTWISE:
+        if kind is ExprKind.ELEMENTWISE:
             return combine_metadata(ce, *ces, to_single_output=False, current_node=node)
-        if node.kind is ExprKind.FILTRATION:
+        if kind is ExprKind.FILTRATION:
             return self.with_filtration(node)
-        if node.kind is ExprKind.ORDERABLE_WINDOW:
+        if kind is ExprKind.ORDERABLE_WINDOW:
             return self.with_orderable_window(node)
-        if node.kind is ExprKind.ORDERABLE_FILTRATION:
+        if kind is ExprKind.ORDERABLE_FILTRATION:
             return self.with_orderable_filtration(node)
-        if node.kind is ExprKind.ORDERABLE_AGGREGATION:
+        if kind is ExprKind.ORDERABLE_AGGREGATION:
             return self.with_orderable_aggregation(node)
-        if node.kind is ExprKind.WINDOW:
+        if kind is ExprKind.WINDOW:
             return self.with_window(node)
-        if node.kind is ExprKind.OVER:
+        if kind is ExprKind.OVER:
             if node.kwargs["order_by"]:
                 return self.with_ordered_over(node)
             if not node.kwargs["partition_by"]:  # pragma: no cover
                 msg = "At least one of `partition_by` or `order_by` must be specified."
                 raise InvalidOperationError(msg)
             return self.with_partitioned_over(node)
-        msg = f"Unexpected node kind: {node.kind}"  # pragma: no cover
+        msg = f"Unexpected node kind: {kind}"  # pragma: no cover
         raise AssertionError(msg)  # pragma: no cover
 
     @classmethod

--- a/narwhals/_expression_parsing.py
+++ b/narwhals/_expression_parsing.py
@@ -380,6 +380,7 @@ class ExprMetadata:
         raise TypeError(msg)
 
     def __repr__(self) -> str:  # pragma: no cover
+        nodes = tuple(reversed(tuple(self.iter_nodes_reversed())))
         return (
             f"ExprMetadata(\n"
             f"  expansion_kind: {self.expansion_kind},\n"
@@ -389,19 +390,9 @@ class ExprMetadata:
             f"  preserves_length: {self.preserves_length},\n"
             f"  is_scalar_like: {self.is_scalar_like},\n"
             f"  is_literal: {self.is_literal},\n"
-            f"  nodes: {tuple(self.iter_nodes())},\n"
+            f"  nodes: {nodes},\n"
             ")"
         )
-
-    def iter_nodes(self) -> Iterator[ExprNode]:  # pragma: no cover
-        """Iterate through all nodes from root to current."""
-        nodes: list[ExprNode] = []
-        current: ExprMetadata | None = self
-        while current is not None:
-            nodes.append(current.current_node)
-            current = current.prev
-        # Reverse to get from root to current
-        return iter(reversed(nodes))
 
     def iter_nodes_reversed(self) -> Iterator[ExprNode]:
         """Iterate through all nodes from current to root."""

--- a/narwhals/_expression_parsing.py
+++ b/narwhals/_expression_parsing.py
@@ -393,7 +393,7 @@ class ExprMetadata:
             ")"
         )
 
-    def iter_nodes(self) -> Iterator[ExprNode]:
+    def iter_nodes(self) -> Iterator[ExprNode]:  # pragma: no cover
         """Iterate through all nodes from root to current."""
         nodes: list[ExprNode] = []
         current: ExprMetadata | None = self


### PR DESCRIPTION
Following up on 

> I have an idea I want to try out - hopefully I can get there soon

(from https://github.com/narwhals-dev/narwhals/pull/3152#pullrequestreview-3326864587)

---

Commits:

1. https://github.com/MarcoGorelli/narwhals/commit/edc117deff9598e940f712d76b3547314ce8bf83: This is the main idea I wanted to try. I am not sure if you were going to like it or not. The main purpose is to avoid having to create a new tuple for each operation (`nodes=(*self.nodes, node)` which compounds back for each node) while we can simply use a reference 

2. https://github.com/MarcoGorelli/narwhals/commit/639b9965a20498befb896b6e319c795c2e49fb63: This is a follow up on another comment I made. Happy to revert