### PR TITLE
refactor: Proposed when-then refactor

### DIFF
--- a/narwhals/functions.py
+++ b/narwhals/functions.py
@@ -1433,9 +1433,10 @@ def when(*predicates: IntoExpr | Iterable[IntoExpr]) -> When:
     """Start a `when-then-otherwise` expression.
 
     Expression similar to an `if-else` statement in Python. Always initiated by a
-    `pl.when(<condition>).then(<value if condition>)`, and optionally followed by a
-    `.otherwise(<value if condition is false>)` can be appended at the end. If not
-    appended, and the condition is not `True`, `None` will be returned.
+    `nw.when(<condition>).then(<value if condition>)`, and optionally followed by
+    chained `.when(<condition>).then(<value>)` calls.
+    An `.otherwise(<value if condition is false>)` can be appended at the end.
+    If not appended, and the condition is not `True`, `None` will be returned.
 
     Arguments:
         predicates: Condition(s) that must be met in order to apply the subsequent

--- a/narwhals/stable/v2/__init__.py
+++ b/narwhals/stable/v2/__init__.py
@@ -880,9 +880,10 @@ def when(*predicates: IntoExpr | Iterable[IntoExpr]) -> When:
     """Start a `when-then-otherwise` expression.
 
     Expression similar to an `if-else` statement in Python. Always initiated by a
-    `pl.when(<condition>).then(<value if condition>)`, and optionally followed by a
-    `.otherwise(<value if condition is false>)` can be appended at the end. If not
-    appended, and the condition is not `True`, `None` will be returned.
+    `nw.when(<condition>).then(<value if condition>)`, and optionally followed by
+    chained `.when(<condition>).then(<value>)` calls.
+    An `.otherwise(<value if condition is false>)` can be appended at the end.
+    If not appended, and the condition is not `True`, `None` will be returned.
 
     Arguments:
         predicates: Condition(s) that must be met in order to apply the subsequent

--- a/tests/expr_and_series/when_test.py
+++ b/tests/expr_and_series/when_test.py
@@ -573,3 +573,32 @@ def test_when_chain_boolean_column_condition(constructor: Constructor) -> None:
     # Row 3: a=False, b=4 >2 -> 200
     expected = {"result": [100, 300, 100, 200]}
     assert_equal_data(result, expected)
+
+
+def test_when_chain_branching_does_not_mutate(constructor: Constructor) -> None:
+    df = nw.from_native(constructor({"a": [1, 2, 3, 4]}))
+
+    base_expr = nw.when(nw.col("a") == 1).then(10)
+    derived_expr = base_expr.when(nw.col("a") > 2).then(nw.col("a") * 10).otherwise(0)
+
+    result = df.select(base_expr.alias("base"), derived_expr.alias("derived"))
+    expected = {"base": [10, None, None, None], "derived": [10, 0, 30, 40]}
+    assert_equal_data(result, expected)
+
+
+def test_when_then_composes_with_expr_operations(constructor: Constructor) -> None:
+    df = nw.from_native(constructor({"a": [1, 2, 3, 4]}))
+
+    result = df.select(
+        (
+            nw.when(nw.col("a") < 3)
+            .then(nw.col("a"))
+            .when(nw.col("a") == 3)
+            .then(10)
+            .otherwise(0)
+            * 2
+        ).alias("result")
+    )
+
+    expected = {"result": [2, 4, 20, 0]}
+    assert_equal_data(result, expected)


### PR DESCRIPTION
# Description

Ciao @MarcoGorelli - this was probably faster than suggesting the changes in the PR. There are a few levels of suggestions here:

- https://github.com/MarcoGorelli/narwhals/commit/b5a8ddf879504d9d15273eaeabbfd76e3ef83d5d is just a docstring suggestion
- https://github.com/MarcoGorelli/narwhals/commit/c074b25544572281a9d6e71bcf55e9f6fb999c7e is a tiny refactor to avoid the same repeated pattern
- https://github.com/MarcoGorelli/narwhals/commit/572552590cf78b3f8e888f584ed5c52831e60364 and https://github.com/MarcoGorelli/narwhals/commit/41f88af7aaa06dbd43de193d148c1b164bf2c049 try to avoid to build the pattern _each time_ eagerly and build it once when needed and cache it. Some parts feel hacky but I believe the idea is reasonable

## What type of PR is this? (check all applicable)

- [x] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [x] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other
